### PR TITLE
feat(docs): update theming docs to illustrate required parameters

### DIFF
--- a/source/Documentation/Theming.mint
+++ b/source/Documentation/Theming.mint
@@ -45,9 +45,11 @@ component Documentation.Theming {
                 "  connect Ui exposing { mobile }",
                 "",
                 "  fun render : Html {",
-                "    <Ui.Theme.Root>",
+                "   <Ui.Theme.Root",
+                "     fontConfiguration={Ui:DEFAULT_FONT_CONFIGURATION}",
+                "     tokens={Ui:DEFAULT_TOKENS}>",
                 "      /* Content goes here. */",
-                "    </Ui.Theme.Root>",
+                "   </Ui.Theme.Root>",
                 "  }",
                 "}"
               ]


### PR DESCRIPTION
Theming documentation does not make it clear what attributes are required on Ui.Theme.Root. When trying to get started with MintUI, I had to look at the doc's website source code to find these default tokens. They should definitely be listed somewhere, and this seems like a reasonable spot.